### PR TITLE
use Remotes: to install sva from bioconductor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,9 @@ RoxygenNote: 6.0.1
 Depends:
     R (>= 2.10),
     Matrix
+Remotes:
+    bioc::release/sva
 Imports:
-    sva,
     mgcv,
     irlba,
     RANN,


### PR DESCRIPTION
I tried to install MUDAN and got:

	$ R CMD INSTALL .
	* installing to library ‘/Library/Frameworks/R.framework/Versions/3.6/Resources/library’
	ERROR: dependency ‘sva’ is not available for package ‘MUDAN’
	* removing ‘/Library/Frameworks/R.framework/Versions/3.6/Resources/library/MUDAN’

This pull request eliminates the installation error that I ran into.

```diff
diff --git a/DESCRIPTION b/DESCRIPTION
index acc33fe..512801b 100644
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,9 @@ RoxygenNote: 6.0.1
 Depends:
     R (>= 2.10),
     Matrix
+Remotes:
+    bioc::release/sva
 Imports:
-    sva,
     mgcv,
     irlba,
     RANN,
```

This page shows how we can use `Remotes:` to install from Bioconductor, GitHub, GitLab, or other sources:

https://cran.r-project.org/web/packages/devtools/vignettes/dependencies.html
