### PR TITLE
add biocViews to the DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ License: GPL-3 + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
+biocViews:
 Depends:
     R (>= 2.10),
     Matrix


### PR DESCRIPTION
I'm making the following PR, as I noticed this discussion: https://github.com/JEFworks/MUDAN/pull/4
CC @slowkow 

I think there's some misunderstanding, as the `biocViews:` within the `DESCRIPTION` is used for devtools. 

One can see this with the travis builds, e.g. 

```
The downloaded source packages are in
	‘/tmp/RtmpSvLVpx/downloaded_packages’
Installing R packages from GitHub: JEFworks/MUDAN
$ Rscript -e 'remotes::install_github(c("JEFworks/MUDAN"))'
Using bundled GitHub PAT. Please add your own PAT to the env var `GITHUB_PAT`
Downloading GitHub repo JEFworks/MUDAN@master
sva          (NA -> 3.36.0  ) [CRAN]
...

Installing 47 packages: sva, irlba, RANN, igraph, Rtsne, ROCR, entropy, BiocGenerics, AnnotationDbi, annotate, Biobase, XML, DBI, xtable, RCurl, IRanges, RSQLite, S4Vectors, bitops, bit64, blob, memoise, pkgconfig, Rcpp, BH, plogr, bit, rlang, vctrs, ellipsis, glue, futile.logger, snow, lambda.r, futile.options, formatR, limma, locfit, gtools, gdata, caTools, genefilter, BiocParallel, matrixStats, edgeR, magrittr, gplots
Installing packages into ‘/home/travis/R/Library’
(as ‘lib’ is unspecified)
trying URL 'https://bioconductor.org/packages/3.11/bioc/src/contrib/sva_3.36.0.tar.gz'
Content type 'application/x-gzip' length 441903 bytes (431 KB)
==================================================
downloaded 431 KB
...
etc.
```